### PR TITLE
release 1.2.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Minepreggo
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU GPLv3
 # The mod version. See https://semver.org/
-mod_version=1.2.8
+mod_version=1.2.9
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/dev/dixmk/minepreggo/MinepreggoMod.java
+++ b/src/main/java/dev/dixmk/minepreggo/MinepreggoMod.java
@@ -482,8 +482,6 @@ public class MinepreggoMod {
         	BrewingRecipeRegistry.addRecipe(new InfertilityPotionBrewingRecipe());
         	BrewingRecipeRegistry.addRecipe(new MetabolismControlPotionBrewingRecipe());
         	BrewingRecipeRegistry.addRecipe(new LongMetabolismControlPotionBrewingRecipe());
-        	BrewingRecipeRegistry.addRecipe(new PregnancyHealingBrewingRecipe());
-        	BrewingRecipeRegistry.addRecipe(new PregnancyHealingBrewingRecipe());
         	BrewingRecipeRegistry.addRecipe(new PregnancyResistancePotionBrewingRecipe());
         	BrewingRecipeRegistry.addRecipe(new LongPregnancyResistancePotionBrewingRecipe());
         	BrewingRecipeRegistry.addRecipe(new ZeroGravityBellyPotionBrewingRecipe());

--- a/src/main/java/dev/dixmk/minepreggo/init/MinepreggoModPotions.java
+++ b/src/main/java/dev/dixmk/minepreggo/init/MinepreggoModPotions.java
@@ -14,84 +14,70 @@ public class MinepreggoModPotions {
 	private MinepreggoModPotions() {}
 	
 	public static final DeferredRegister<Potion> REGISTRY = DeferredRegister.create(ForgeRegistries.POTIONS, MinepreggoMod.MODID);
-	public static final RegistryObject<Potion> IMPREGNATION_POTION_0 = REGISTRY.register("impregnation_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.IMPREGNANTION.get(), 300, 0, false, true)));
-	public static final RegistryObject<Potion> IMPREGNATION_POTION_1 = REGISTRY.register("impregnation_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.IMPREGNANTION.get(), 300, 1, false, true)));
-	public static final RegistryObject<Potion> IMPREGNATION_POTION_2 = REGISTRY.register("impregnation_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.IMPREGNANTION.get(), 300, 2, false, true)));
-	public static final RegistryObject<Potion> IMPREGNATION_POTION_3 = REGISTRY.register("impregnation_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.IMPREGNANTION.get(), 300, 3, false, true)));
-	public static final RegistryObject<Potion> IMPREGNATION_POTION_4 = REGISTRY.register("impregnation_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.IMPREGNANTION.get(), 300, 4, false, true)));
-	
-	public static final RegistryObject<Potion> ZOMBIE_IMPREGNATION_0 = REGISTRY.register("zombie_impregnation_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ZOMBIE_IMPREGNATION.get(), 300, 0, false, true)));
-	public static final RegistryObject<Potion> ZOMBIE_IMPREGNATION_1 = REGISTRY.register("zombie_impregnation_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ZOMBIE_IMPREGNATION.get(), 300, 1, false, true)));
-	public static final RegistryObject<Potion> ZOMBIE_IMPREGNATION_2 = REGISTRY.register("zombie_impregnation_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ZOMBIE_IMPREGNATION.get(), 300, 2, false, true)));
-	public static final RegistryObject<Potion> ZOMBIE_IMPREGNATION_3 = REGISTRY.register("zombie_impregnation_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ZOMBIE_IMPREGNATION.get(), 300, 3, false, true)));
-	public static final RegistryObject<Potion> ZOMBIE_IMPREGNATION_4 = REGISTRY.register("zombie_impregnation_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ZOMBIE_IMPREGNATION.get(), 300, 4, false, true)));
-
-	public static final RegistryObject<Potion> CREEPER_IMPREGNATION_0 = REGISTRY.register("creeper_impregnation_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.CREEPER_IMPREGNATION.get(), 300, 0, false, true)));
-	public static final RegistryObject<Potion> CREEPER_IMPREGNATION_1 = REGISTRY.register("creeper_impregnation_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.CREEPER_IMPREGNATION.get(), 300, 1, false, true)));
-	public static final RegistryObject<Potion> CREEPER_IMPREGNATION_2 = REGISTRY.register("creeper_impregnation_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.CREEPER_IMPREGNATION.get(), 300, 2, false, true)));
-	public static final RegistryObject<Potion> CREEPER_IMPREGNATION_3 = REGISTRY.register("creeper_impregnation_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.CREEPER_IMPREGNATION.get(), 300, 3, false, true)));
-	public static final RegistryObject<Potion> CREEPER_IMPREGNATION_4 = REGISTRY.register("creeper_impregnation_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.CREEPER_IMPREGNATION.get(), 300, 4, false, true)));
-
-	public static final RegistryObject<Potion> HUMANOID_CREEPER_IMPREGNATION_0 = REGISTRY.register("humanoid_creeper_impregnation_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_CREEPER_IMPREGNATION.get(), 300, 0, false, true)));
-	public static final RegistryObject<Potion> HUMANOID_CREEPER_IMPREGNATION_1 = REGISTRY.register("humanoid_creeper_impregnation_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_CREEPER_IMPREGNATION.get(), 300, 1, false, true)));
-	public static final RegistryObject<Potion> HUMANOID_CREEPER_IMPREGNATION_2 = REGISTRY.register("humanoid_creeper_impregnation_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_CREEPER_IMPREGNATION.get(), 300, 2, false, true)));
-	public static final RegistryObject<Potion> HUMANOID_CREEPER_IMPREGNATION_3 = REGISTRY.register("humanoid_creeper_impregnation_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_CREEPER_IMPREGNATION.get(), 300, 3, false, true)));
-	public static final RegistryObject<Potion> HUMANOID_CREEPER_IMPREGNATION_4 = REGISTRY.register("humanoid_creeper_impregnation_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_CREEPER_IMPREGNATION.get(), 300, 4, false, true)));
-
-	public static final RegistryObject<Potion> ENDER_IMPREGNATION_0 = REGISTRY.register("ender_impregnation_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ENDER_IMPREGNATION.get(), 300, 0, false, true)));
-	public static final RegistryObject<Potion> ENDER_IMPREGNATION_1 = REGISTRY.register("ender_impregnation_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ENDER_IMPREGNATION.get(), 300, 1, false, true)));
-	public static final RegistryObject<Potion> ENDER_IMPREGNATION_2 = REGISTRY.register("ender_impregnation_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ENDER_IMPREGNATION.get(), 300, 2, false, true)));
-	public static final RegistryObject<Potion> ENDER_IMPREGNATION_3 = REGISTRY.register("ender_impregnation_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ENDER_IMPREGNATION.get(), 300, 3, false, true)));
-	public static final RegistryObject<Potion> ENDER_IMPREGNATION_4 = REGISTRY.register("ender_impregnation_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ENDER_IMPREGNATION.get(), 300, 4, false, true)));
-
-	public static final RegistryObject<Potion> HUMANOID_ENDER_IMPREGNATION_0 = REGISTRY.register("humanoid_ender_impregnation_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_ENDER_IMPREGNATION.get(), 300, 0, false, true)));
-	public static final RegistryObject<Potion> HUMANOID_ENDER_IMPREGNATION_1 = REGISTRY.register("humanoid_ender_impregnation_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_ENDER_IMPREGNATION.get(), 300, 1, false, true)));
-	public static final RegistryObject<Potion> HUMANOID_ENDER_IMPREGNATION_2 = REGISTRY.register("humanoid_ender_impregnation_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_ENDER_IMPREGNATION.get(), 300, 2, false, true)));
-	public static final RegistryObject<Potion> HUMANOID_ENDER_IMPREGNATION_3 = REGISTRY.register("humanoid_ender_impregnation_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_ENDER_IMPREGNATION.get(), 300, 3, false, true)));
-	public static final RegistryObject<Potion> HUMANOID_ENDER_IMPREGNATION_4 = REGISTRY.register("humanoid_ender_impregnation_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_ENDER_IMPREGNATION.get(), 300, 4, false, true)));
-	
-	public static final RegistryObject<Potion> VILLAGER_IMPREGNATION_0 = REGISTRY.register("villager_impregnation_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.VILLAGER_IMPREGNATION.get(), 300, 0, false, true)));
-	public static final RegistryObject<Potion> VILLAGER_IMPREGNATION_1 = REGISTRY.register("villager_impregnation_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.VILLAGER_IMPREGNATION.get(), 300, 1, false, true)));
-	public static final RegistryObject<Potion> VILLAGER_IMPREGNATION_2 = REGISTRY.register("villager_impregnation_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.VILLAGER_IMPREGNATION.get(), 300, 2, false, true)));
-	public static final RegistryObject<Potion> VILLAGER_IMPREGNATION_3 = REGISTRY.register("villager_impregnation_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.VILLAGER_IMPREGNATION.get(), 300, 3, false, true)));
-	public static final RegistryObject<Potion> VILLAGER_IMPREGNATION_4 = REGISTRY.register("villager_impregnation_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.VILLAGER_IMPREGNATION.get(), 300, 4, false, true)));
-
-	public static final RegistryObject<Potion> PREGNANCY_DELAY_0 = REGISTRY.register("pregnancy_delay_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_DELAY.get(), 1, 0, false, true)));
-	public static final RegistryObject<Potion> PREGNANCY_DELAY_1 = REGISTRY.register("pregnancy_delay_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_DELAY.get(), 1, 1, false, true)));
-	public static final RegistryObject<Potion> PREGNANCY_DELAY_2 = REGISTRY.register("pregnancy_delay_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_DELAY.get(), 1, 2, false, true)));
-	public static final RegistryObject<Potion> PREGNANCY_DELAY_3 = REGISTRY.register("pregnancy_delay_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_DELAY.get(), 1, 3, false, true)));
-	public static final RegistryObject<Potion> PREGNANCY_DELAY_4 = REGISTRY.register("pregnancy_delay_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_DELAY.get(), 1, 4, false, true)));
-	
-	public static final RegistryObject<Potion> BABY_DUPLICATION_0 = REGISTRY.register("baby_duplication_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.BABY_DUPLICATION.get(), 1, 0, false, true)));
-	public static final RegistryObject<Potion> BABY_DUPLICATION_1 = REGISTRY.register("baby_duplication_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.BABY_DUPLICATION.get(), 1, 1, false, true)));
-	public static final RegistryObject<Potion> BABY_DUPLICATION_2 = REGISTRY.register("baby_duplication_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.BABY_DUPLICATION.get(), 1, 2, false, true)));
-	public static final RegistryObject<Potion> BABY_DUPLICATION_3 = REGISTRY.register("baby_duplication_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.BABY_DUPLICATION.get(), 1, 3, false, true)));
-	public static final RegistryObject<Potion> BABY_DUPLICATION_4 = REGISTRY.register("baby_duplication_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.BABY_DUPLICATION.get(), 1, 4, false, true)));
-
-	public static final RegistryObject<Potion> PREGNANCY_ACCELERATION_0 = REGISTRY.register("pregnancy_acceleration_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_ACCELERATION.get(), 1, 0, false, true)));
-	public static final RegistryObject<Potion> PREGNANCY_ACCELERATION_1 = REGISTRY.register("pregnancy_acceleration_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_ACCELERATION.get(), 1, 1, false, true)));
-	public static final RegistryObject<Potion> PREGNANCY_ACCELERATION_2 = REGISTRY.register("pregnancy_acceleration_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_ACCELERATION.get(), 1, 2, false, true)));
-	public static final RegistryObject<Potion> PREGNANCY_ACCELERATION_3 = REGISTRY.register("pregnancy_acceleration_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_ACCELERATION.get(), 1, 3, false, true)));
-	public static final RegistryObject<Potion> PREGNANCY_ACCELERATION_4 = REGISTRY.register("pregnancy_acceleration_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_ACCELERATION.get(), 1, 4, false, true)));
-	
-	public static final RegistryObject<Potion> PREGNANCY_RESISTANCE = REGISTRY.register("pregnancy_resistance", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_RESISTANCE.get(), 9600, 0, false, true)));
-	public static final RegistryObject<Potion> LONG_PREGNANCY_RESISTANCE = REGISTRY.register("long_pregnancy_resistance", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_RESISTANCE.get(), 19200, 0, false, true)));
-
-	public static final RegistryObject<Potion> PREGNANCY_HEALING = REGISTRY.register("pregnancy_healing", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_HEALING.get(), 1, 0, false, true)));	
-	public static final RegistryObject<Potion> PREGNANCY_HARMING = REGISTRY.register("pregnancy_harming", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_HARMING.get(), 1, 0, false, true)));	
-
-	public static final RegistryObject<Potion> FERTILITY = REGISTRY.register("fertility", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.FERTILITY.get(), 1, 0, false, true)));
-	public static final RegistryObject<Potion> INFERTILITY = REGISTRY.register("infertility", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.INFERTILITY.get(), 1, 0, false, true)));
-	public static final RegistryObject<Potion> METABOLISM_CONTROL = REGISTRY.register("metabolism_control", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.METABOLISM_CONTROL.get(), 6000, 0, false, false, true)));
-	public static final RegistryObject<Potion> STRONG_METABOLISM_CONTROL = REGISTRY.register("strong_metabolism_control", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.METABOLISM_CONTROL.get(), 6000, 1, false, false, true)));
-	public static final RegistryObject<Potion> LONG_METABOLISM_CONTROL = REGISTRY.register("long_metabolism_control", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.METABOLISM_CONTROL.get(), 12000, 0, false, false, true)));
-
-	public static final RegistryObject<Potion> ETERNAL_PREGNANCY = REGISTRY.register("eternal_pregnancy", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ETERNAL_PREGNANCY.get(), -1, 0, false, true, true)));
-	public static final RegistryObject<Potion> ZERO_GRAVITY_BELLY = REGISTRY.register("zero_gravity_belly", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ZERO_GRAVITY_BELLY.get(), 9600, 0, false, true, true)));
-	public static final RegistryObject<Potion> LONG_ZERO_GRAVITY_BELLY = REGISTRY.register("long_zero_gravity_belly", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ZERO_GRAVITY_BELLY.get(), 19200, 0, false, true, true)));
-
-	public static final RegistryObject<Potion> ENDER_POWERFUL_IMPREGNATION = REGISTRY.register("ender_powerful_impregnation", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ENDER_IMPREGNATION.get(), 300, 4, false, true), new MobEffectInstance(MobEffects.REGENERATION, 300, 0, false, true), new MobEffectInstance(MobEffects.DAMAGE_RESISTANCE, 12000, 0, false, true)));
-	public static final RegistryObject<Potion> ENDER_DRAGON_IMPREGNATION = REGISTRY.register("ender_dragon_impregnation", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ENDER_DRAGON_IMPREGNATION.get(), 300, 0, false, true)));
+	public static final RegistryObject<Potion> IMPREGNATION_POTION_0 = REGISTRY.register("impregnation_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.IMPREGNANTION.get(), 300, 0)));
+	public static final RegistryObject<Potion> IMPREGNATION_POTION_1 = REGISTRY.register("impregnation_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.IMPREGNANTION.get(), 300, 1)));
+	public static final RegistryObject<Potion> IMPREGNATION_POTION_2 = REGISTRY.register("impregnation_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.IMPREGNANTION.get(), 300, 2)));
+	public static final RegistryObject<Potion> IMPREGNATION_POTION_3 = REGISTRY.register("impregnation_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.IMPREGNANTION.get(), 300, 3)));
+	public static final RegistryObject<Potion> IMPREGNATION_POTION_4 = REGISTRY.register("impregnation_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.IMPREGNANTION.get(), 300, 4)));	
+	public static final RegistryObject<Potion> ZOMBIE_IMPREGNATION_0 = REGISTRY.register("zombie_impregnation_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ZOMBIE_IMPREGNATION.get(), 300, 0)));
+	public static final RegistryObject<Potion> ZOMBIE_IMPREGNATION_1 = REGISTRY.register("zombie_impregnation_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ZOMBIE_IMPREGNATION.get(), 300, 1)));
+	public static final RegistryObject<Potion> ZOMBIE_IMPREGNATION_2 = REGISTRY.register("zombie_impregnation_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ZOMBIE_IMPREGNATION.get(), 300, 2)));
+	public static final RegistryObject<Potion> ZOMBIE_IMPREGNATION_3 = REGISTRY.register("zombie_impregnation_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ZOMBIE_IMPREGNATION.get(), 300, 3)));
+	public static final RegistryObject<Potion> ZOMBIE_IMPREGNATION_4 = REGISTRY.register("zombie_impregnation_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ZOMBIE_IMPREGNATION.get(), 300, 4)));
+	public static final RegistryObject<Potion> CREEPER_IMPREGNATION_0 = REGISTRY.register("creeper_impregnation_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.CREEPER_IMPREGNATION.get(), 300, 0)));
+	public static final RegistryObject<Potion> CREEPER_IMPREGNATION_1 = REGISTRY.register("creeper_impregnation_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.CREEPER_IMPREGNATION.get(), 300, 1)));
+	public static final RegistryObject<Potion> CREEPER_IMPREGNATION_2 = REGISTRY.register("creeper_impregnation_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.CREEPER_IMPREGNATION.get(), 300, 2)));
+	public static final RegistryObject<Potion> CREEPER_IMPREGNATION_3 = REGISTRY.register("creeper_impregnation_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.CREEPER_IMPREGNATION.get(), 300, 3)));
+	public static final RegistryObject<Potion> CREEPER_IMPREGNATION_4 = REGISTRY.register("creeper_impregnation_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.CREEPER_IMPREGNATION.get(), 300, 4)));
+	public static final RegistryObject<Potion> HUMANOID_CREEPER_IMPREGNATION_0 = REGISTRY.register("humanoid_creeper_impregnation_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_CREEPER_IMPREGNATION.get(), 300, 0)));
+	public static final RegistryObject<Potion> HUMANOID_CREEPER_IMPREGNATION_1 = REGISTRY.register("humanoid_creeper_impregnation_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_CREEPER_IMPREGNATION.get(), 300, 1)));
+	public static final RegistryObject<Potion> HUMANOID_CREEPER_IMPREGNATION_2 = REGISTRY.register("humanoid_creeper_impregnation_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_CREEPER_IMPREGNATION.get(), 300, 2)));
+	public static final RegistryObject<Potion> HUMANOID_CREEPER_IMPREGNATION_3 = REGISTRY.register("humanoid_creeper_impregnation_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_CREEPER_IMPREGNATION.get(), 300, 3)));
+	public static final RegistryObject<Potion> HUMANOID_CREEPER_IMPREGNATION_4 = REGISTRY.register("humanoid_creeper_impregnation_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_CREEPER_IMPREGNATION.get(), 300, 4)));
+	public static final RegistryObject<Potion> ENDER_IMPREGNATION_0 = REGISTRY.register("ender_impregnation_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ENDER_IMPREGNATION.get(), 300, 0)));
+	public static final RegistryObject<Potion> ENDER_IMPREGNATION_1 = REGISTRY.register("ender_impregnation_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ENDER_IMPREGNATION.get(), 300, 1)));
+	public static final RegistryObject<Potion> ENDER_IMPREGNATION_2 = REGISTRY.register("ender_impregnation_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ENDER_IMPREGNATION.get(), 300, 2)));
+	public static final RegistryObject<Potion> ENDER_IMPREGNATION_3 = REGISTRY.register("ender_impregnation_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ENDER_IMPREGNATION.get(), 300, 3)));
+	public static final RegistryObject<Potion> ENDER_IMPREGNATION_4 = REGISTRY.register("ender_impregnation_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ENDER_IMPREGNATION.get(), 300, 4)));
+	public static final RegistryObject<Potion> HUMANOID_ENDER_IMPREGNATION_0 = REGISTRY.register("humanoid_ender_impregnation_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_ENDER_IMPREGNATION.get(), 300, 0)));
+	public static final RegistryObject<Potion> HUMANOID_ENDER_IMPREGNATION_1 = REGISTRY.register("humanoid_ender_impregnation_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_ENDER_IMPREGNATION.get(), 300, 1)));
+	public static final RegistryObject<Potion> HUMANOID_ENDER_IMPREGNATION_2 = REGISTRY.register("humanoid_ender_impregnation_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_ENDER_IMPREGNATION.get(), 300, 2)));
+	public static final RegistryObject<Potion> HUMANOID_ENDER_IMPREGNATION_3 = REGISTRY.register("humanoid_ender_impregnation_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_ENDER_IMPREGNATION.get(), 300, 3)));
+	public static final RegistryObject<Potion> HUMANOID_ENDER_IMPREGNATION_4 = REGISTRY.register("humanoid_ender_impregnation_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.HUMANOID_ENDER_IMPREGNATION.get(), 300, 4)));
+	public static final RegistryObject<Potion> VILLAGER_IMPREGNATION_0 = REGISTRY.register("villager_impregnation_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.VILLAGER_IMPREGNATION.get(), 300, 0)));
+	public static final RegistryObject<Potion> VILLAGER_IMPREGNATION_1 = REGISTRY.register("villager_impregnation_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.VILLAGER_IMPREGNATION.get(), 300, 1)));
+	public static final RegistryObject<Potion> VILLAGER_IMPREGNATION_2 = REGISTRY.register("villager_impregnation_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.VILLAGER_IMPREGNATION.get(), 300, 2)));
+	public static final RegistryObject<Potion> VILLAGER_IMPREGNATION_3 = REGISTRY.register("villager_impregnation_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.VILLAGER_IMPREGNATION.get(), 300, 3)));
+	public static final RegistryObject<Potion> VILLAGER_IMPREGNATION_4 = REGISTRY.register("villager_impregnation_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.VILLAGER_IMPREGNATION.get(), 300, 4)));
+	public static final RegistryObject<Potion> PREGNANCY_DELAY_0 = REGISTRY.register("pregnancy_delay_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_DELAY.get(), 1, 0)));
+	public static final RegistryObject<Potion> PREGNANCY_DELAY_1 = REGISTRY.register("pregnancy_delay_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_DELAY.get(), 1, 1)));
+	public static final RegistryObject<Potion> PREGNANCY_DELAY_2 = REGISTRY.register("pregnancy_delay_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_DELAY.get(), 1, 2)));
+	public static final RegistryObject<Potion> PREGNANCY_DELAY_3 = REGISTRY.register("pregnancy_delay_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_DELAY.get(), 1, 3)));
+	public static final RegistryObject<Potion> PREGNANCY_DELAY_4 = REGISTRY.register("pregnancy_delay_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_DELAY.get(), 1, 4)));
+	public static final RegistryObject<Potion> BABY_DUPLICATION_0 = REGISTRY.register("baby_duplication_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.BABY_DUPLICATION.get(), 1, 0)));
+	public static final RegistryObject<Potion> BABY_DUPLICATION_1 = REGISTRY.register("baby_duplication_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.BABY_DUPLICATION.get(), 1, 1)));
+	public static final RegistryObject<Potion> BABY_DUPLICATION_2 = REGISTRY.register("baby_duplication_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.BABY_DUPLICATION.get(), 1, 2)));
+	public static final RegistryObject<Potion> BABY_DUPLICATION_3 = REGISTRY.register("baby_duplication_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.BABY_DUPLICATION.get(), 1, 3)));
+	public static final RegistryObject<Potion> BABY_DUPLICATION_4 = REGISTRY.register("baby_duplication_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.BABY_DUPLICATION.get(), 1, 4)));
+	public static final RegistryObject<Potion> PREGNANCY_ACCELERATION_0 = REGISTRY.register("pregnancy_acceleration_0", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_ACCELERATION.get(), 1, 0)));
+	public static final RegistryObject<Potion> PREGNANCY_ACCELERATION_1 = REGISTRY.register("pregnancy_acceleration_1", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_ACCELERATION.get(), 1, 1)));
+	public static final RegistryObject<Potion> PREGNANCY_ACCELERATION_2 = REGISTRY.register("pregnancy_acceleration_2", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_ACCELERATION.get(), 1, 2)));
+	public static final RegistryObject<Potion> PREGNANCY_ACCELERATION_3 = REGISTRY.register("pregnancy_acceleration_3", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_ACCELERATION.get(), 1, 3)));
+	public static final RegistryObject<Potion> PREGNANCY_ACCELERATION_4 = REGISTRY.register("pregnancy_acceleration_4", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_ACCELERATION.get(), 1, 4)));
+	public static final RegistryObject<Potion> PREGNANCY_RESISTANCE = REGISTRY.register("pregnancy_resistance", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_RESISTANCE.get(), 9600, 0)));
+	public static final RegistryObject<Potion> LONG_PREGNANCY_RESISTANCE = REGISTRY.register("long_pregnancy_resistance", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_RESISTANCE.get(), 19200, 0)));
+	public static final RegistryObject<Potion> PREGNANCY_HEALING = REGISTRY.register("pregnancy_healing", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_HEALING.get(), 1)));	
+	public static final RegistryObject<Potion> PREGNANCY_HARMING = REGISTRY.register("pregnancy_harming", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.PREGNANCY_HARMING.get(), 1)));	
+	public static final RegistryObject<Potion> FERTILITY = REGISTRY.register("fertility", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.FERTILITY.get(), 1, 0)));
+	public static final RegistryObject<Potion> INFERTILITY = REGISTRY.register("infertility", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.INFERTILITY.get(), 1, 0)));
+	public static final RegistryObject<Potion> METABOLISM_CONTROL = REGISTRY.register("metabolism_control", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.METABOLISM_CONTROL.get(), 6000, 0)));
+	public static final RegistryObject<Potion> STRONG_METABOLISM_CONTROL = REGISTRY.register("strong_metabolism_control", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.METABOLISM_CONTROL.get(), 6000, 1)));
+	public static final RegistryObject<Potion> LONG_METABOLISM_CONTROL = REGISTRY.register("long_metabolism_control", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.METABOLISM_CONTROL.get(), 12000, 0)));
+	public static final RegistryObject<Potion> ETERNAL_PREGNANCY = REGISTRY.register("eternal_pregnancy", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ETERNAL_PREGNANCY.get(), -1, 0)));
+	public static final RegistryObject<Potion> ZERO_GRAVITY_BELLY = REGISTRY.register("zero_gravity_belly", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ZERO_GRAVITY_BELLY.get(), 9600, 0)));
+	public static final RegistryObject<Potion> LONG_ZERO_GRAVITY_BELLY = REGISTRY.register("long_zero_gravity_belly", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ZERO_GRAVITY_BELLY.get(), 19200, 0)));
+	public static final RegistryObject<Potion> ENDER_POWERFUL_IMPREGNATION = REGISTRY.register("ender_powerful_impregnation", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ENDER_IMPREGNATION.get(), 300, 4), new MobEffectInstance(MobEffects.REGENERATION, 300, 0), new MobEffectInstance(MobEffects.DAMAGE_RESISTANCE, 12000, 0)));
+	public static final RegistryObject<Potion> ENDER_DRAGON_IMPREGNATION = REGISTRY.register("ender_dragon_impregnation", () -> new Potion(new MobEffectInstance(MinepreggoModMobEffects.ENDER_DRAGON_IMPREGNATION.get(), 300, 0)));
 
 	public static Potion getRandomImpregnationPotion(RandomSource random) {
 		return switch (random.nextInt(5)) {

--- a/src/main/java/dev/dixmk/minepreggo/world/effect/BabyDuplication.java
+++ b/src/main/java/dev/dixmk/minepreggo/world/effect/BabyDuplication.java
@@ -36,23 +36,23 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageTypes;
-import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.InstantenousMobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.MobSpawnType;
 
-public class BabyDuplication extends MobEffect {
+public class BabyDuplication extends InstantenousMobEffect {
 
 	public BabyDuplication() {
 		super(MobEffectCategory.HARMFUL, -39220);
 	}
 	
-	@Override
-	public boolean isInstantenous() {
-		return true;
-	}
+    @Override
+    public void applyEffectTick(LivingEntity target, int amplifier) {
+        applyInstantenousEffect(null, null, target, amplifier, 1.0D);
+    }
 	
     @Override
     public void applyInstantenousEffect(@Nullable Entity source, @Nullable Entity indirectSource, LivingEntity target, int amplifier, double effectiveness) {     

--- a/src/main/java/dev/dixmk/minepreggo/world/effect/Fertility.java
+++ b/src/main/java/dev/dixmk/minepreggo/world/effect/Fertility.java
@@ -5,17 +5,22 @@ import javax.annotation.Nullable;
 import dev.dixmk.minepreggo.init.MinepreggoCapabilities;
 import dev.dixmk.minepreggo.world.entity.preggo.ITamablePreggoMob;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.InstantenousMobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 
-public class Fertility extends MobEffect {
+public class Fertility extends InstantenousMobEffect {
 
 	public Fertility() {
 		super(MobEffectCategory.BENEFICIAL, -10027213);
 	}
 
+    @Override
+    public void applyEffectTick(LivingEntity target, int amplifier) {
+        applyInstantenousEffect(null, null, target, amplifier, 1.0D);
+    }
+	
 	@Override
 	public void applyInstantenousEffect(@Nullable Entity p_19462_, @Nullable Entity p_19463_, LivingEntity p_19464_, int p_19465_, double p_19466_) { 		
 		if (p_19464_.level().isClientSide) {
@@ -34,10 +39,5 @@ public class Fertility extends MobEffect {
 				})
 			);			
 		}
-	}
-	
-	@Override
-	public boolean isInstantenous() {
-		return true;
 	}
 }

--- a/src/main/java/dev/dixmk/minepreggo/world/effect/Infertility.java
+++ b/src/main/java/dev/dixmk/minepreggo/world/effect/Infertility.java
@@ -5,17 +5,22 @@ import javax.annotation.Nullable;
 import dev.dixmk.minepreggo.init.MinepreggoCapabilities;
 import dev.dixmk.minepreggo.world.entity.preggo.ITamablePreggoMob;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.InstantenousMobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 
-public class Infertility extends MobEffect {
+public class Infertility extends InstantenousMobEffect {
 
 	public Infertility() {
 		super(MobEffectCategory.HARMFUL, -10053376);
 	}
-
+	
+    @Override
+    public void applyEffectTick(LivingEntity target, int amplifier) {
+        applyInstantenousEffect(null, null, target, amplifier, 1.0D);
+    }
+	
 	@Override
 	public void applyInstantenousEffect(@Nullable Entity p_19462_, @Nullable Entity p_19463_, LivingEntity p_19464_, int p_19465_, double p_19466_) { 		
 		if (p_19464_.level().isClientSide) {
@@ -35,10 +40,5 @@ public class Infertility extends MobEffect {
 				})
 			);			
 		}
-	}
-	
-	@Override
-	public boolean isInstantenous() {
-		return true;
 	}
 }

--- a/src/main/java/dev/dixmk/minepreggo/world/effect/PregnancyAcceleration.java
+++ b/src/main/java/dev/dixmk/minepreggo/world/effect/PregnancyAcceleration.java
@@ -14,12 +14,12 @@ import dev.dixmk.minepreggo.world.pregnancy.PregnancyPhase;
 import dev.dixmk.minepreggo.world.pregnancy.PregnancyPhaseHelper;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.InstantenousMobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 
-public class PregnancyAcceleration extends MobEffect {
+public class PregnancyAcceleration extends InstantenousMobEffect {
     
     private static final float[][] PERCETANGES_RANGES = {
             {0.1f, 0.2f},
@@ -31,6 +31,11 @@ public class PregnancyAcceleration extends MobEffect {
 	
     public PregnancyAcceleration() {
         super(MobEffectCategory.HARMFUL, -52429);
+    }
+    
+    @Override
+    public void applyEffectTick(LivingEntity target, int amplifier) {
+        applyInstantenousEffect(null, null, target, amplifier, 1.0D);
     }
 
     @Override
@@ -66,11 +71,6 @@ public class PregnancyAcceleration extends MobEffect {
         maxDays = Math.min(maxDays, totalPregnancyDays); // Don't exceed total days
 
         return random.nextInt(minDays, maxDays + 1); // upper bound is exclusive, so +1
-    }
-
-    @Override
-    public boolean isInstantenous() {
-        return true;
     }
     
     private static void apply(IPregnancyData handler, int days) {

--- a/src/main/java/dev/dixmk/minepreggo/world/effect/PregnancyDelay.java
+++ b/src/main/java/dev/dixmk/minepreggo/world/effect/PregnancyDelay.java
@@ -14,12 +14,12 @@ import dev.dixmk.minepreggo.world.pregnancy.PregnancyPhase;
 import dev.dixmk.minepreggo.world.pregnancy.PregnancyPhaseHelper;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.InstantenousMobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 
-public class PregnancyDelay extends MobEffect {
+public class PregnancyDelay extends InstantenousMobEffect {
 
     private static final float[][] PERCETANGES_RANGES = {
             {0.1f, 0.2f},
@@ -33,10 +33,10 @@ public class PregnancyDelay extends MobEffect {
 		super(MobEffectCategory.HARMFUL, -39220);
 	}
 	
-	@Override
-	public boolean isInstantenous() {
-		return true;
-	}
+    @Override
+    public void applyEffectTick(LivingEntity target, int amplifier) {
+        applyInstantenousEffect(null, null, target, amplifier, 1.0D);
+    }
 	
 	@Override
 	public void applyInstantenousEffect(@Nullable Entity source, @Nullable Entity indirectSource, LivingEntity target, int amplifier, double effectiveness) {

--- a/src/main/java/dev/dixmk/minepreggo/world/effect/PregnancyHarming.java
+++ b/src/main/java/dev/dixmk/minepreggo/world/effect/PregnancyHarming.java
@@ -10,15 +10,20 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageTypes;
-import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.InstantenousMobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 
-public class PregnancyHarming extends MobEffect {
+public class PregnancyHarming extends InstantenousMobEffect {
 	public PregnancyHarming() {
 		super(MobEffectCategory.HARMFUL, -3407821);
 	}
+	
+    @Override
+    public void applyEffectTick(LivingEntity target, int amplifier) {
+        applyInstantenousEffect(null, null, target, amplifier, 1.0D);
+    }
 	
 	@Override
 	public void applyInstantenousEffect(@Nullable Entity p_19462_, @Nullable Entity p_19463_, LivingEntity p_19464_, int p_19465_, double p_19466_) { 
@@ -43,11 +48,5 @@ public class PregnancyHarming extends MobEffect {
 				})
 			);			
 		}
-	}
-	
-
-	@Override
-	public boolean isInstantenous() {
-		return true;
 	}
 }

--- a/src/main/java/dev/dixmk/minepreggo/world/effect/PregnancyHealing.java
+++ b/src/main/java/dev/dixmk/minepreggo/world/effect/PregnancyHealing.java
@@ -8,16 +8,21 @@ import dev.dixmk.minepreggo.world.entity.preggo.ITamablePregnantPreggoMob;
 import dev.dixmk.minepreggo.world.pregnancy.PregnancySystemHelper;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.InstantenousMobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 
-public class PregnancyHealing extends MobEffect {
+public class PregnancyHealing extends InstantenousMobEffect {
 	
 	public PregnancyHealing() {
 		super(MobEffectCategory.BENEFICIAL, -3407821);
 	}
+	
+    @Override
+    public void applyEffectTick(LivingEntity target, int amplifier) {
+        applyInstantenousEffect(null, null, target, amplifier, 1.0D);
+    }
 	
 	@Override
 	public void applyInstantenousEffect(@Nullable Entity p_19462_, @Nullable Entity p_19463_, LivingEntity p_19464_, int p_19465_, double p_19466_) { 
@@ -40,10 +45,5 @@ public class PregnancyHealing extends MobEffect {
 				})
 			);			
 		}
-	}
-	
-	@Override
-	public boolean isInstantenous() {
-		return true;
 	}
 }

--- a/src/main/java/dev/dixmk/minepreggo/world/entity/preggo/PreggoMobPregnancySystemP1.java
+++ b/src/main/java/dev/dixmk/minepreggo/world/entity/preggo/PreggoMobPregnancySystemP1.java
@@ -139,10 +139,10 @@ public abstract class PreggoMobPregnancySystemP1
 		if (pregnancyData.getPregnancyPainTimer() < PregnancySystemHelper.TOTAL_TICKS_MISCARRIAGE) {
         	pregnancyData.setPregnancyPainTimer(pregnancyData.getPregnancyPainTimer() + 1);	        		        	
 			if (pregnantEntity instanceof AbstractEnderWoman) {
-	    		AbstractPregnancySystem.spawnParticulesForWaterBreaking(serverLevel, pregnantEntity, pregnantEntity.getBbHeight() * 0.65);
+	    		AbstractPregnancySystem.spawnParticulesForMiscarriage(serverLevel, pregnantEntity, pregnantEntity.getBbHeight() * 0.65);
 			}
 			else {
-	    		AbstractPregnancySystem.spawnParticulesForWaterBreaking(serverLevel, pregnantEntity);
+	    		AbstractPregnancySystem.spawnParticulesForMiscarriage(serverLevel, pregnantEntity);
 			}
         } else {      	
         	final List<ItemStack> deadBabiesItemStacks = PregnancySystemHelper.getDeadBabies(pregnancyData.getWomb());   	

--- a/src/main/java/dev/dixmk/minepreggo/world/item/alchemy/ImpregnationPotionBrewingRecipe.java
+++ b/src/main/java/dev/dixmk/minepreggo/world/item/alchemy/ImpregnationPotionBrewingRecipe.java
@@ -74,7 +74,7 @@ public abstract class ImpregnationPotionBrewingRecipe implements IBrewingRecipe 
 
 		@Override
 		public boolean isIngredient(ItemStack ingredient) {
-			return ingredient.is(Items.NETHER_QUARTZ_ORE);
+			return ingredient.is(Items.QUARTZ);
 		}
 
 		@Override

--- a/src/main/java/dev/dixmk/minepreggo/world/item/alchemy/PregnancyAccelerationPotionBrewingRecipe.java
+++ b/src/main/java/dev/dixmk/minepreggo/world/item/alchemy/PregnancyAccelerationPotionBrewingRecipe.java
@@ -62,7 +62,7 @@ public abstract class PregnancyAccelerationPotionBrewingRecipe implements IBrewi
 
 		@Override
 		public boolean isIngredient(ItemStack ingredient) {
-			return ingredient.is(Items.NETHER_QUARTZ_ORE);
+			return ingredient.is(Items.QUARTZ);
 		}
 
 		@Override

--- a/src/main/java/dev/dixmk/minepreggo/world/item/alchemy/PregnancyDelayPotionBrewingRecipe.java
+++ b/src/main/java/dev/dixmk/minepreggo/world/item/alchemy/PregnancyDelayPotionBrewingRecipe.java
@@ -62,7 +62,7 @@ public abstract class PregnancyDelayPotionBrewingRecipe implements IBrewingRecip
 
 		@Override
 		public boolean isIngredient(ItemStack ingredient) {
-			return ingredient.is(Items.NETHER_QUARTZ_ORE);
+			return ingredient.is(Items.QUARTZ);
 		}
 
 		@Override


### PR DESCRIPTION
*fix arrows that use instantenous mob effect from minepreggo does not apply their effects (baby duplication, fertility, infertility, pregnancy acceleration, pregnancy delay, pregnancy harming, pregnancy healing *fix type of particle when preggomob goes miscarriage